### PR TITLE
fix: malformed output

### DIFF
--- a/cfn_guard_test/__init__.py
+++ b/cfn_guard_test/__init__.py
@@ -77,17 +77,16 @@ def main(
         output_callback=resolve_output_callback(verbose),
     ).execute()
 
-    list(map(click.echo, suites.failed_suites_messages))
+    if junit_path:
+        CfnGuardReport(suites).write(junit_path)
 
     click.echo()
     click.echo(f"Passed {suites.passed}")
     click.echo(f"Failed {suites.failed}")
     click.echo()
 
-    if junit_path:
-        CfnGuardReport(suites).write(junit_path)
-
     if suites.failed:
+        list(map(click.echo, suites.failed_suites_messages))
         exit(1)
 
 

--- a/cfn_guard_test/case.py
+++ b/cfn_guard_test/case.py
@@ -52,7 +52,7 @@ class CfnGuardTestCase:
         messages: List[str] = []
 
         def extend(rule: CfnGuardRule) -> None:
-            messages.extend(
+            messages.append(
                 rule.failed_message(
                     suite_name=suite_name, case_number=self.number, case_name=self.name
                 )

--- a/cfn_guard_test/runner.py
+++ b/cfn_guard_test/runner.py
@@ -21,8 +21,8 @@ class CfnGuardRunner:
         output_callback: Optional[Callable[[str], None]] = None,
     ):
         self.cfn_guard_path = cfn_guard_path
-        self.rules_path = rules_path
-        self.test_path = test_path
+        self.rules_path = rules_path.rstrip("/")
+        self.test_path = test_path.rstrip("/")
         self.output_callback = output_callback
 
     def __print(self, message: str) -> None:


### PR DESCRIPTION
**Issue #, if available:** #4 and #9

## Description of changes:

When paths were supplied with a trailing slash. It resulted in two slashes in the printed path in the output.
With the introduction of JUnit reports in #9 the output was even more broken. The failure message was extended to the list but it needed to be added.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
