### PR TITLE
fix: ignored tests

### DIFF
--- a/cfn_guard_test/__init__.py
+++ b/cfn_guard_test/__init__.py
@@ -81,12 +81,26 @@ def main(
         CfnGuardReport(suites).write(junit_path)
 
     click.echo()
-    click.echo(f"Passed {suites.passed}")
+    click.echo(f"Errors {suites.errors}")
     click.echo(f"Failed {suites.failed}")
+    click.echo(f"Passed {suites.passed}")
     click.echo()
+    display_failures_errors(suites)
+
+
+def display_failures_errors(suites: CfnGuardTestSuites) -> None:
+
+    if suites.errors:
+        click.echo(click.style("Errors:", bold=True))
+        list(map(click.echo, suites.error_messages))
+        click.echo()
 
     if suites.failed:
-        list(map(click.echo, suites.failed_suites_messages))
+        click.echo(click.style("Failures:", bold=True))
+        list(map(click.echo, suites.failure_messages))
+        click.echo()
+
+    if suites.errors or suites.failed:
         exit(1)
 
 

--- a/cfn_guard_test/case.py
+++ b/cfn_guard_test/case.py
@@ -31,9 +31,17 @@ class CfnGuardTestCase:
         return self.__number
 
     @property
+    def message(self) -> str:
+        return ""
+
+    @property
     def passed(self) -> int:
         rules = self.passed_rules
         return len(rules) if rules else 0
+
+    @property
+    def errors(self) -> int:
+        return 0
 
     @property
     def failed(self) -> int:
@@ -64,3 +72,17 @@ class CfnGuardTestCase:
     @property
     def passed_rules(self) -> List[CfnGuardRule]:
         return list(filter(lambda case: case.passed, self.__rules))
+
+
+class ErrorTestCase(CfnGuardTestCase):
+    def __init__(self, message: str) -> None:
+        super().__init__(name="Loading Error", number=1)
+        self.__message = message
+
+    @property
+    def errors(self) -> int:
+        return 1
+
+    @property
+    def message(self) -> str:
+        return self.__message

--- a/cfn_guard_test/suite.py
+++ b/cfn_guard_test/suite.py
@@ -30,6 +30,11 @@ class CfnGuardTestSuite:
         return self.__duration
 
     @property
+    def errors(self) -> int:
+        rules = self.error_test_cases
+        return len(rules) if rules else 0
+
+    @property
     def passed(self) -> int:
         rules = self.passed_test_cases
         return len(rules) if rules else 0
@@ -44,18 +49,29 @@ class CfnGuardTestSuite:
         return self.__cases
 
     @property
+    def error_test_cases(self) -> List[CfnGuardTestCase]:
+        return list(filter(lambda case: case.errors, self.__cases))
+
+    @property
     def failed_test_cases(self) -> List[CfnGuardTestCase]:
         return list(filter(lambda case: case.failed, self.__cases))
+
+    @property
+    def error_messages(self) -> List[str]:
+        messages = []
+        list(map(lambda case: messages.append(case.message), self.error_test_cases))
+        return messages
 
     @property
     def failed_test_cases_messages(self) -> List[str]:
         messages = []
 
         def extend(case: CfnGuardTestCase) -> None:
+            messages.append(case.message)
             messages.extend(case.failed_rules_messages(suite_name=self.ruleset))
 
         list(map(extend, self.failed_test_cases))
-        return messages
+        return list(filter(None, messages))
 
     @property
     def passed_test_cases(self) -> List[CfnGuardTestCase]:

--- a/cfn_guard_test/suites.py
+++ b/cfn_guard_test/suites.py
@@ -18,6 +18,10 @@ class CfnGuardTestSuites:
         self.__suites.append(case)
 
     @property
+    def errors(self) -> int:
+        return sum(map(lambda suite: suite.errors, self.error_suites), 0)
+
+    @property
     def passed(self) -> int:
         return sum(map(lambda suite: suite.passed, self.passed_suites), 0)
 
@@ -31,10 +35,22 @@ class CfnGuardTestSuites:
 
     @property
     def failed_suites(self) -> List[CfnGuardTestSuite]:
-        return list(filter(lambda case: case.failed, self.__suites))
+        return list(filter(lambda suite: suite.failed, self.__suites))
 
     @property
-    def failed_suites_messages(self) -> List[str]:
+    def error_suites(self) -> List[CfnGuardTestSuite]:
+        return list(filter(lambda suite: suite.errors, self.__suites))
+
+    @property
+    def error_messages(self) -> List[str]:
+        messages = []
+        list(
+            map(lambda suite: messages.extend(suite.error_messages), self.error_suites)
+        )
+        return messages
+
+    @property
+    def failure_messages(self) -> List[str]:
         messages = []
 
         def extend(suite: CfnGuardTestSuite) -> None:
@@ -45,4 +61,4 @@ class CfnGuardTestSuites:
 
     @property
     def passed_suites(self) -> List[CfnGuardTestSuite]:
-        return list(filter(lambda case: case.passed, self.__suites))
+        return list(filter(lambda suite: suite.passed, self.__suites))


### PR DESCRIPTION
**Issue #, if available:** #15

## Description of changes:

When you have malformed YAML tests. Or the output of `cfn-guard` could not be read. We skipped it and went to the next one. This resulted in a scenario where you might think your test ran successfully. But in reallity they where skipped.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
