### PR TITLE
feat: include the cfn-guard loading error

### DIFF
--- a/cfn_guard_test/case.py
+++ b/cfn_guard_test/case.py
@@ -75,9 +75,9 @@ class CfnGuardTestCase:
 
 
 class ErrorTestCase(CfnGuardTestCase):
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: str, details: str) -> None:
         super().__init__(name="Loading Error", number=1)
-        self.__message = message
+        self.__message = message + "\n\n" + details
 
     @property
     def errors(self) -> int:

--- a/cfn_guard_test/reader.py
+++ b/cfn_guard_test/reader.py
@@ -34,7 +34,8 @@ class CfnGuardReader:
 
         if not self.__valid_report:
             case = ErrorTestCase(
-                message=f"Unable to read the output when testing '{rule_name}'!"
+                message=f"Unable to read the output when testing '{rule_name}'!",
+                details=report.decode("utf-8"),
             )
             self.__suite.add_test_case(case)
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -184,6 +184,11 @@ def test_invoke_cfn_guard_failure(
     runner = CliRunner()
     result = runner.invoke(main, [])
     assert result.exit_code == 1
+    assert "Unable to read the output when testing 'rules/iam.guard'!" in result.stdout
+    assert (
+        "Error processing Parser Error when parsing Unable to process data in file..."
+        in result.stdout
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

When cfn-guard is not capable of running a test. For example when the test yaml has an invalid format. We include the append the error message to the message fed to the wrapper. This will give additional context on what went wrong.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
